### PR TITLE
Add aarch64 support

### DIFF
--- a/plugins/de.tudresden.slr.parent/pom.xml
+++ b/plugins/de.tudresden.slr.parent/pom.xml
@@ -209,6 +209,11 @@
 							<ws>cocoa</ws>
 							<arch>x86_64</arch>
 						</environment>
+						<environment>
+							<os>macosx</os>
+							<ws>cocoa</ws>
+							<arch>aarch64</arch>
+						</environment>
 					</environments>
 				</configuration>
 			</plugin>


### PR DESCRIPTION
Support for macOS with aarch64 would be nice (e.g. for newer, apple silicon macbooks).
Maybe this PR might already be sufficient, as it adds the environment for aarch64 to the parent pom.

I could not test it, as the build failed for me locally even before my changes due to:
```
Failed to resolve target definition /slr-toolkit/targets/de.tudresden.slr.target/de.tudresden.slr.target.target: 
Failed to load p2 metadata repository from location https://download.eclipse.org/modeling/emft/mwe/updates/milestones/S201910141054/: 
No repository found at https://download.eclipse.org/modeling/emft/mwe/updates/milestones/S201910141054.
```